### PR TITLE
Add basic Express setup with /ping route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.env

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "s65_autocorrect_disasters",
   "version": "1.0.0",
   "description": "A platform for sharing and discovering humorous autocorrect disasters with personalized recommendations.",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
+    "start": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -18,6 +19,9 @@
   },
   "homepage": "https://github.com/kalviumcommunity/S65_Autocorrect_Disasters#readme",
   "dependencies": {
-    "express": "^4.21.2"
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5",
+    "nodemon": "^3.1.9"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+
+app.get('/ping', function (req, res) {
+  res.send('pong');
+});
+
+const PORT = 6000;
+app.listen(PORT, function () {
+  console.log('Server is running on port ' + PORT);
+});


### PR DESCRIPTION
This pull request introduces a foundational Express.js setup for our application. It includes the creation of a simple /ping route that responds with a basic message, allowing us to verify that the server is running correctly. This setup lays the groundwork for further development and integration of additional routes and features in the future.